### PR TITLE
feat: introduce regex caching

### DIFF
--- a/src/main/kotlin/com/devlee/ipranges/core/io/RangeFileUtil.kt
+++ b/src/main/kotlin/com/devlee/ipranges/core/io/RangeFileUtil.kt
@@ -16,6 +16,8 @@ class RangeFileUtil {
 
         private const val RANGE_FILE_PATH = "./range/"
 
+        private val regexCache: MutableMap<Provider, List<Regex>> = mutableMapOf()
+
         fun findAllRegex(): List<IPRegex> {
             val regexFiles = File(RANGE_FILE_PATH)
 

--- a/src/main/kotlin/com/devlee/ipranges/core/io/RangeFileUtil.kt
+++ b/src/main/kotlin/com/devlee/ipranges/core/io/RangeFileUtil.kt
@@ -26,30 +26,6 @@ class RangeFileUtil {
             return Provider.entries.flatMap { getRegex(it) }
         }
 
-        fun findAllRegex(): List<IPRegex> {
-            val regexFiles = File(RANGE_FILE_PATH)
-
-            if (!regexFiles.exists() || regexFiles.listFiles().isNullOrEmpty()) {
-                throw NoSuchFileException(regexFiles)
-            }
-
-            val ipRegexList = mutableListOf<IPRegex>()
-
-            regexFiles.listFiles()?.forEach { regexFile ->
-                val regexFileList = regexFile.listFiles()
-
-                val regexDocument = regexFileList?.getOrNull(0)
-
-                regexDocument?.run {
-                    ipRegexList.addAll(
-                        jsonFormat.decodeFromString(this.readText())
-                    )
-                }
-            }
-
-            return ipRegexList
-        }
-
         fun findRegex(provider: Provider): List<IPRegex> {
             val regexFile = File(RANGE_FILE_PATH + createRegexFileName(provider))
 

--- a/src/main/kotlin/com/devlee/ipranges/core/io/RangeFileUtil.kt
+++ b/src/main/kotlin/com/devlee/ipranges/core/io/RangeFileUtil.kt
@@ -26,16 +26,6 @@ class RangeFileUtil {
             return Provider.entries.flatMap { getRegex(it) }
         }
 
-        fun findRegex(provider: Provider): List<IPRegex> {
-            val regexFile = File(RANGE_FILE_PATH + createRegexFileName(provider))
-
-            if (!regexFile.exists()) {
-                throw NoSuchFileException(regexFile)
-            }
-
-            return jsonFormat.decodeFromString<List<IPRegex>>(regexFile.readText())
-        }
-
         fun updateRangeFile(provider: Provider, rangeParse: () -> List<IPRanges>) {
             val regexFile = createFileData(createRegexFileName(provider))
             val rangeFile = createFileData(createRangeFileName(provider))
@@ -61,6 +51,16 @@ class RangeFileUtil {
 
             rangeFile.writeText(jsonFormat.encodeToString(rangeList))
             regexFile.writeText(jsonFormat.encodeToString(regexList))
+        }
+
+        private fun findRegex(provider: Provider): List<IPRegex> {
+            val regexFile = File(RANGE_FILE_PATH + createRegexFileName(provider))
+
+            if (!regexFile.exists()) {
+                throw NoSuchFileException(regexFile)
+            }
+
+            return jsonFormat.decodeFromString<List<IPRegex>>(regexFile.readText())
         }
 
         private fun createFileData(fileName: String): File =

--- a/src/main/kotlin/com/devlee/ipranges/core/io/RangeFileUtil.kt
+++ b/src/main/kotlin/com/devlee/ipranges/core/io/RangeFileUtil.kt
@@ -22,6 +22,10 @@ class RangeFileUtil {
             return regexCache.getOrPut(provider) { findRegex(provider) }
         }
 
+        fun getAllRegex(): List<IPRegex> {
+            return Provider.entries.flatMap { getRegex(it) }
+        }
+
         fun findAllRegex(): List<IPRegex> {
             val regexFiles = File(RANGE_FILE_PATH)
 

--- a/src/main/kotlin/com/devlee/ipranges/core/io/RangeFileUtil.kt
+++ b/src/main/kotlin/com/devlee/ipranges/core/io/RangeFileUtil.kt
@@ -16,7 +16,11 @@ class RangeFileUtil {
 
         private const val RANGE_FILE_PATH = "./range/"
 
-        private val regexCache: MutableMap<Provider, List<Regex>> = mutableMapOf()
+        private val regexCache: MutableMap<Provider, List<IPRegex>> = mutableMapOf()
+
+        fun getRegex(provider: Provider): List<IPRegex> {
+            return regexCache.getOrPut(provider) { findRegex(provider) }
+        }
 
         fun findAllRegex(): List<IPRegex> {
             val regexFiles = File(RANGE_FILE_PATH)

--- a/src/main/kotlin/com/devlee/ipranges/util/IPRangeUtil.kt
+++ b/src/main/kotlin/com/devlee/ipranges/util/IPRangeUtil.kt
@@ -13,7 +13,7 @@ class IPRangeUtil {
                 throw UnknownHostException("Invalid IP Address")
             }
 
-            val regexes = RangeFileUtil.findAllRegex()
+            val regexes = RangeFileUtil.getAllRegex()
 
             return regexes.any { regexList ->
                 run {
@@ -27,7 +27,7 @@ class IPRangeUtil {
                 throw UnknownHostException("Invalid IP Address")
             }
 
-            val regexes = RangeFileUtil.findRegex(provider)
+            val regexes = RangeFileUtil.getRegex(provider)
 
             return regexes.any { regexList ->
                 run {
@@ -41,7 +41,7 @@ class IPRangeUtil {
                 throw UnknownHostException("Invalid IP Address")
             }
 
-            val regexes = RangeFileUtil.findRegex(provider)
+            val regexes = RangeFileUtil.getRegex(provider)
 
             return regexes.any { regexList ->
                 run {


### PR DESCRIPTION
- Move regex construction logic to RangeFileUtil with internal map caching
- Replace inline regex creation with getRegex() / getAllRegex() calls
- Restrict raw regex JSON accessors to private